### PR TITLE
Fix allowing graphs to use different dictionaries

### DIFF
--- a/ehrp-api-master/ehrp_utils.py
+++ b/ehrp-api-master/ehrp_utils.py
@@ -20,7 +20,6 @@ RESOURCES_RELATIVE_PATH = 'resources'
 GRAMMAR_RELATIVE_PATH = os.path.join(RESOURCES_RELATIVE_PATH, 'Grammars')
 DICTIONARY_RELATIVE_PATH = os.path.join(RESOURCES_RELATIVE_PATH, 'Dictionaries')
 
-
 # Called from ehrp_api.py
 def load_alphabets(options):
     ''' Place alphabets in persistent space for re-use. '''

--- a/ehrp-api-master/ehrp_utils.py
+++ b/ehrp-api-master/ehrp_utils.py
@@ -20,6 +20,7 @@ RESOURCES_RELATIVE_PATH = 'resources'
 GRAMMAR_RELATIVE_PATH = os.path.join(RESOURCES_RELATIVE_PATH, 'Grammars')
 DICTIONARY_RELATIVE_PATH = os.path.join(RESOURCES_RELATIVE_PATH, 'Dictionaries')
 
+
 # Called from ehrp_api.py
 def load_alphabets(options):
     ''' Place alphabets in persistent space for re-use. '''
@@ -33,7 +34,7 @@ def free_alphabets(options):
     free_persistent_alphabet(options['resources']['alphabet-sorted'])
 
 # Called from ehrp_api.py
-def extract_concepts(options, all_groupings, text, concepts_to_get='ALL'):
+def extract_concepts(options, all_groupings, dicts_and_ontos, text, concepts_to_get='ALL'):
     '''
     Extracts concepts from text.
     Returns dictionary of found concepts.
@@ -76,7 +77,7 @@ def extract_concepts(options, all_groupings, text, concepts_to_get='ALL'):
     tokenize_text(snt, alphabet_unsorted, options["tools"]["tokenize"])
 
     # Get concepts that match grammars
-    concepts = get_concepts_for_grammars(dirc, options, snt, alphabet_unsorted, alphabet_sorted, chosen_groupings)
+    concepts = get_concepts_for_grammars(dirc, options, snt, alphabet_unsorted, alphabet_sorted, chosen_groupings, dicts_and_ontos)
 
     # Clean the Unitex files
     print("Cleaning up files from " + dirc)
@@ -93,7 +94,7 @@ def extract_concepts(options, all_groupings, text, concepts_to_get='ALL'):
 # alphabet_unsorted: file path to alphabet unitex should use, unsorted
 # alphabet_sorted: file path to alphabet unitex should use, sorted
 # groupings: list of dictionary objects holding info from GRAMMAR_DICTIONARY_PARSING_GROUPS_PATH
-def get_concepts_for_grammars(directory, options, snt, alphabet_unsorted, alphabet_sorted, concepts):
+def get_concepts_for_grammars(directory, options, snt, alphabet_unsorted, alphabet_sorted, concepts, dicts_and_ontos):
     list_of_concepts = []
 
     # Set arguments that don't change across grammar/dictionary usage
@@ -102,17 +103,16 @@ def get_concepts_for_grammars(directory, options, snt, alphabet_unsorted, alphab
         options = options,
         text = snt,
         alphabet_unsorted = alphabet_unsorted,
-        alphabet_sorted = alphabet_sorted
+        alphabet_sorted = alphabet_sorted,
+        dictionaries = dicts_and_ontos['dictionaries'],
+        ontology_names = dicts_and_ontos['ontologies']
     )
 
     # Set concept_parser grammar, dictionaries, and parsing_functions to those in GrammarDictionaryParsingFunction.py
     for grammar_dictionary_parser in concepts:
         grammar_path = os.path.join(GRAMMAR_RELATIVE_PATH, grammar_dictionary_parser['grammar'])
-        dictionary_paths = [ os.path.join(DICTIONARY_RELATIVE_PATH, dictionary) for dictionary in grammar_dictionary_parser['dictionaries'] ]
 
         concept_parser.grammar = grammar_path
-        concept_parser.dictionaries = dictionary_paths
-        concept_parser.ontology_names = grammar_dictionary_parser['ontologies']
         concept_parser.parsing_function = grammar_dictionary_parser['parsing_function']
 
         # Make use of ConceptParser member variables that might not be set during object construction
@@ -132,7 +132,7 @@ def get_concepts_for_grammars(directory, options, snt, alphabet_unsorted, alphab
 
     return list_of_concepts
 
-def get_groupings_from_file(file_path):
+def get_json_from_file(file_path):
     ''' Loads the user-chosen groupings of grammars, dictionaries, and parsing functions as a dictionary '''
     with open(file_path) as file:
         groupings = json.load(file)
@@ -188,3 +188,7 @@ def tokenize_text(snt_file_path, alphabet, kwargs):
 def incorrect_concept_type(incorrect_type):
     # Unprocessable entity error
     abort(422)
+
+def dict_names_to_paths(dict_names):
+    ''' Changes dictionary names to dictionary paths '''
+    return [os.path.join(DICTIONARY_RELATIVE_PATH, name) for name in dict_names]

--- a/ehrp-api-master/resources/DictsAndOntologies.json
+++ b/ehrp-api-master/resources/DictsAndOntologies.json
@@ -1,0 +1,22 @@
+{
+  "dictionaries": [
+    "Meddra.bin",
+    "DrugBank.bin",
+    "RxNorm.bin",
+    "OrangeBook.bin",
+    "RxNorm_Tradenames.bin",
+    "RxNorm_Ingredients.bin",
+    "ATC_Ingredients.bin",
+    "FDB_Ingredients.bin",
+    "DrugsAtFDA.bin"
+  ],
+  "ontologies": [
+    "Meddra",
+    "DrugBank",
+    "RxNorm",
+    "OrangeBook",
+    "ATC",
+    "NDDF",
+    "DrugsAtFDA"
+  ]
+}

--- a/ehrp-api-master/resources/GrammarDictionaryParsingFunction.json
+++ b/ehrp-api-master/resources/GrammarDictionaryParsingFunction.json
@@ -1,216 +1,44 @@
 [
   {
     "grammar": "lookup.fst2",
-    "dictionaries": [
-      "DrugBank.bin",
-      "RxNorm.bin",
-      "OrangeBook.bin",
-      "RxNorm_Tradenames.bin",
-      "RxNorm_Ingredients.bin",
-      "ATC_Ingredients.bin",
-      "FDB_Ingredients.bin",
-      "Meddra.bin",
-      "DrugsAtFDA.bin"
-    ],
-    "ontologies": [
-      "DrugBank",
-      "Meddra",
-      "RxNorm",
-      "OrangeBook",
-      "ATC",
-      "NDDF",
-      "DrugsAtFDA"
-    ],
     "parsing_function": "lookupParser"
   },
   {
     "grammar": "drug.fst2",
-    "dictionaries": [
-      "DrugBank.bin",
-      "RxNorm.bin",
-      "OrangeBook.bin",
-      "RxNorm_Tradenames.bin",
-      "RxNorm_Ingredients.bin",
-      "ATC_Ingredients.bin",
-      "FDB_Ingredients.bin",
-      "DrugsAtFDA.bin"
-    ],
-    "ontologies": [
-      "DrugBank",
-      "RxNorm",
-      "OrangeBook",
-      "ATC",
-      "NDDF",
-      "DrugsAtFDA"
-    ],
     "parsing_function": "drugParser",
     "sub_graph": "True"
   },
   {
     "grammar": "prescription.fst2",
-    "dictionaries": [
-      "DrugBank.bin",
-      "RxNorm.bin",
-      "OrangeBook.bin",
-      "RxNorm_Tradenames.bin",
-      "RxNorm_Ingredients.bin",
-      "ATC_Ingredients.bin",
-      "FDB_Ingredients.bin",
-      "DrugsAtFDA.bin"
-    ],
-    "ontologies": [
-      "DrugBank",
-      "RxNorm",
-      "OrangeBook",
-      "ATC",
-      "NDDF",
-      "DrugsAtFDA"
-    ],
     "parsing_function": "prescriptionParser"
   },
   {
     "grammar": "disorder.fst2",
-    "dictionaries": [
-      "Meddra.bin"
-    ],
-    "ontologies": [
-      "Meddra"
-    ],
     "parsing_function": "disorderParser"
   },
   {
     "grammar": "chf.fst2",
-    "dictionaries": [
-      "DrugBank.bin",
-      "RxNorm.bin",
-      "OrangeBook.bin",
-      "RxNorm_Tradenames.bin",
-      "RxNorm_Ingredients.bin",
-      "ATC_Ingredients.bin",
-      "FDB_Ingredients.bin",
-      "DrugsAtFDA.bin"
-    ],
-    "ontologies": [
-      "DrugBank",
-      "RxNorm",
-      "OrangeBook",
-      "ATC",
-      "NDDF",
-      "DrugsAtFDA"
-    ],
     "parsing_function": "chfParser"
   },
   {
     "grammar": "ami.fst2",
-    "dictionaries": [
-      "DrugBank.bin",
-      "RxNorm.bin",
-      "OrangeBook.bin",
-      "RxNorm_Tradenames.bin",
-      "RxNorm_Ingredients.bin",
-      "ATC_Ingredients.bin",
-      "FDB_Ingredients.bin",
-      "DrugsAtFDA.bin"
-    ],
-    "ontologies": [
-      "DrugBank",
-      "RxNorm",
-      "OrangeBook",
-      "ATC",
-      "NDDF",
-      "DrugsAtFDA"
-    ],
     "parsing_function": "amiParser"
   },
   {
     "grammar": "pna.fst2",
-    "dictionaries": [
-      "DrugBank.bin",
-      "RxNorm.bin",
-      "OrangeBook.bin",
-      "RxNorm_Tradenames.bin",
-      "RxNorm_Ingredients.bin",
-      "ATC_Ingredients.bin",
-      "FDB_Ingredients.bin",
-      "DrugsAtFDA.bin"
-    ],
-    "ontologies": [
-      "DrugBank",
-      "RxNorm",
-      "OrangeBook",
-      "ATC",
-      "NDDF",
-      "DrugsAtFDA"
-    ],
     "parsing_function": "pnaParser"
   },
   {
     "grammar": "comorbidity.fst2",
-    "dictionaries": [
-      "DrugBank.bin",
-      "RxNorm.bin",
-      "OrangeBook.bin",
-      "RxNorm_Tradenames.bin",
-      "RxNorm_Ingredients.bin",
-      "ATC_Ingredients.bin",
-      "FDB_Ingredients.bin",
-      "DrugsAtFDA.bin"
-    ],
-    "ontologies": [
-      "DrugBank",
-      "RxNorm",
-      "OrangeBook",
-      "ATC",
-      "NDDF",
-      "DrugsAtFDA"
-    ],
     "parsing_function": "comorbidityParser"
   },
   {
     "grammar": "pt_summary.fst2",
-    "dictionaries": [
-      "DrugBank.bin",
-      "RxNorm.bin",
-      "OrangeBook.bin",
-      "RxNorm_Tradenames.bin",
-      "RxNorm_Ingredients.bin",
-      "ATC_Ingredients.bin",
-      "FDB_Ingredients.bin",
-      "DrugsAtFDA.bin"
-    ],
-    "ontologies": [
-      "DrugBank",
-      "RxNorm",
-      "OrangeBook",
-      "ATC",
-      "NDDF",
-      "DrugsAtFDA"
-    ],
     "parsing_function": "pt_summaryParser",
     "sub_graph": "True"
   },
   {
     "grammar": "master.fst2",
-    "dictionaries": [
-      "DrugBank.bin",
-      "RxNorm.bin",
-      "OrangeBook.bin",
-      "RxNorm_Tradenames.bin",
-      "RxNorm_Ingredients.bin",
-      "ATC_Ingredients.bin",
-      "FDB_Ingredients.bin",
-      "DrugsAtFDA.bin",
-      "Meddra.bin"
-    ],
-    "ontologies": [
-      "DrugBank",
-      "RxNorm",
-      "OrangeBook",
-      "ATC",
-      "NDDF",
-      "DrugsAtFDA",
-      "Meddra"
-    ],
     "parsing_function": "masterParser"
   }
 ]


### PR DESCRIPTION
Separated dictionary and ontology names from graph and parsing function json.

Now all graphs use all the available dictionaries. Can no longer specify which dictionaries to use per graph. It should always be the case that more information is better. If a graph is being hindered by a dictionary, then the graph is not prepared well.
