### PR TITLE
Fixed escaped commas parsing

### DIFF
--- a/ehrp-api-master/DictionaryParser.py
+++ b/ehrp-api-master/DictionaryParser.py
@@ -1,3 +1,5 @@
+import re
+
 ''' Creates two dict objects:
         one maps concept names to concept ids,
         one maps concept names to ontology they come from
@@ -20,8 +22,9 @@ class DictionaryParser():
     def parse_dictionaries(self):
         for entity in self.entities:
             # This is expected format, need to make dictionary comply with expected format
-            parts = entity.split(',')
+            parts = re.split(r'(?<!\\),', entity)
             label = parts[0]
+            label = label.replace('\\,', ',')
             cid = parts[-1].split('.')[0]
 
             # Get ontology name based on if ontology name in entity. Should be exactly one ontology name per entity.


### PR DESCRIPTION
The DictionaryParser class was not checking for escaped commas.
So, it was splitting dictionary entries on escaped commas sometimes, which resulted in some concepts with commas in their strings not being recognized.