### PR TITLE
Moccbc/restful api

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ ___
 
   #### Lookup
   + `lookup` functionality is accessible through a `GET` request to the following URL<br>
-    URL : http://localhost:8020/ehrp/lookup<br>
+    URL : http://localhost:8020/ehrp/v1/lookup<br>
     ##### Parameters
     + Required:<br>
       + Name: 'text'
@@ -33,7 +33,7 @@ ___
         + Description: This should be the term you want to lookup.<br>
 
     ##### Example request:
-    + GET: http://localhost:8020/ehrp/lookup?text=hypertension
+    + GET: http://localhost:8020/ehrp/v1/lookup?text=hypertension
     + RESPONSE:<br>
     ```
     [
@@ -49,7 +49,7 @@ ___
 
 #### Extract
   + `extract` functionality is accessible through a `POST` request to the following URL<br>
-    URL : http://localhost:8020/ehrp/extract
+    URL : http://localhost:8020/ehrp/v1/extract
     ##### Parameters
     + Optional:
       + Name: 'text'
@@ -84,7 +84,7 @@ ___
         }
         
         text_file = open('medical_text_path', 'rb')
-        response = requests.post('http://localhost:8021/ehrp/extract', data=args, files={'file': text_file))
+        response = requests.post('http://localhost:8021/ehrp/v1/extract', data=args, files={'file': text_file))
         ```
 
 Both GET and POST requests return JSON objects.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ ___
           'text': [medical_text_string1, medical_text_string2],
           'types': 'drug'
         }
-        response = requests.post('http://localhost:8021/ehrp/extract', data=args)
+        response = requests.post('http://localhost:8021/ehrp/v1/extract', data=args)
         ```
         + Possible values for 'types':  
           + 'drug': Looks for drug names

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ ___
 
   #### Lookup
   + `lookup` functionality is accessible through a `GET` request to the following URL<br>
-    URL : http://localhost:8020/ehrp/v1/lookup<br>
+    URL : http://localhost:8020/ehrp-api/v1/terms<br>
     ##### Parameters
     + Required:<br>
       + Name: 'text'
@@ -33,7 +33,7 @@ ___
         + Description: This should be the term you want to lookup.<br>
 
     ##### Example request:
-    + GET: http://localhost:8020/ehrp/v1/lookup?text=hypertension
+    + GET: http://localhost:8020/ehrp-api/v1/terms?text=hypertension
     + RESPONSE:<br>
     ```
     [
@@ -49,7 +49,7 @@ ___
 
 #### Extract
   + `extract` functionality is accessible through a `POST` request to the following URL<br>
-    URL : http://localhost:8020/ehrp/v1/extract
+    URL : http://localhost:8020/ehrp-api/v1/ehrs
     ##### Parameters
     + Optional:
       + Name: 'text'
@@ -65,7 +65,7 @@ ___
           'text': [medical_text_string1, medical_text_string2],
           'types': 'drug'
         }
-        response = requests.post('http://localhost:8021/ehrp/v1/extract', data=args)
+        response = requests.post('http://localhost:8021/ehrp-api/v1/ehrs', data=args)
         ```
         + Possible values for 'types':  
           + 'drug': Looks for drug names
@@ -84,7 +84,7 @@ ___
         }
         
         text_file = open('medical_text_path', 'rb')
-        response = requests.post('http://localhost:8021/ehrp/v1/extract', data=args, files={'file': text_file))
+        response = requests.post('http://localhost:8021/ehrp-api/v1/ehrs', data=args, files={'file': text_file))
         ```
 
 Both GET and POST requests return JSON objects.

--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ ___
     URL : http://localhost:8020/ehrp-api/v1/terms<br>
     ##### Parameters
     + Required:<br>
-      + Name: 'text'
+      + Name: 'term'
         + Type: string
         + Description: This should be the term you want to lookup.<br>
 
     ##### Example request:
-    + GET: http://localhost:8020/ehrp-api/v1/terms?text=hypertension
+    + GET: http://localhost:8020/ehrp-api/v1/terms?term=hypertension
     + RESPONSE:<br>
     ```
     [

--- a/ehrp-api-master/ehrp_api.py
+++ b/ehrp-api-master/ehrp_api.py
@@ -104,7 +104,7 @@ def main():
     parser.add_argument('--host', type=str, default='localhost',
                         help="Host name (default: localhost)")
     parser.add_argument('--port', type=int, default='8020', help="Port (default: 8020)")
-    parser.add_argument('--path', type=str, default='/ehrp', help="Path (default: /ehrp)")
+    # parser.add_argument('--path', type=str, default='/ehrp', help="Path (default: /ehrp)")
     args = parser.parse_args()
 
     # Load resources
@@ -123,8 +123,13 @@ def main():
     ALL_DICTS_AND_ONTOLOGIES['dictionaries'] = dict_names_to_paths(ALL_DICTS_AND_ONTOLOGIES['dictionaries'])
 
     print("Starting app . . .")
+    ''''''
+    print('args: ', args)
+    # print('args.path: ', args.path)
+    print('args.conf: ', args.conf)
+    ''''''
     app = Flask(__name__)
-    api = Api(app)
+    api = Api(app, prefix='/ehrp/v1')
 
     # Handle missing page 404 error
     @app.errorhandler(404)
@@ -139,8 +144,10 @@ def main():
         return error
 
     # Make extract and lookup pages available
-    api.add_resource(Extract, args.path+'/extract')
-    api.add_resource(Lookup, args.path+'/lookup')
+    # api.add_resource(Extract, args.path+'/extract')
+    # api.add_resource(Lookup, args.path+'/lookup')
+    api.add_resource(Extract, '/extract')
+    api.add_resource(Lookup, '/lookup')
     app.run(host=args.host, port=args.port)
 
     # Free resources

--- a/ehrp-api-master/ehrp_api.py
+++ b/ehrp-api-master/ehrp_api.py
@@ -104,7 +104,6 @@ def main():
     parser.add_argument('--host', type=str, default='localhost',
                         help="Host name (default: localhost)")
     parser.add_argument('--port', type=int, default='8020', help="Port (default: 8020)")
-    # parser.add_argument('--path', type=str, default='/ehrp', help="Path (default: /ehrp)")
     args = parser.parse_args()
 
     # Load resources
@@ -123,13 +122,12 @@ def main():
     ALL_DICTS_AND_ONTOLOGIES['dictionaries'] = dict_names_to_paths(ALL_DICTS_AND_ONTOLOGIES['dictionaries'])
 
     print("Starting app . . .")
-    ''''''
-    print('args: ', args)
-    # print('args.path: ', args.path)
-    print('args.conf: ', args.conf)
-    ''''''
     app = Flask(__name__)
-    api = Api(app, prefix='/ehrp/v1')
+    # Running DEBUG mode for flask. Makes JSON outputs more readable.
+    ''''''
+    app.config['DEBUG'] = True
+    ''''''
+    api = Api(app, prefix='/ehrp-api/v1')
 
     # Handle missing page 404 error
     @app.errorhandler(404)
@@ -144,10 +142,8 @@ def main():
         return error
 
     # Make extract and lookup pages available
-    # api.add_resource(Extract, args.path+'/extract')
-    # api.add_resource(Lookup, args.path+'/lookup')
-    api.add_resource(Extract, '/extract')
-    api.add_resource(Lookup, '/lookup')
+    api.add_resource(Extract, '/ehrs')
+    api.add_resource(Lookup, '/terms')
     app.run(host=args.host, port=args.port)
 
     # Free resources

--- a/ehrp-api-master/ehrp_api.py
+++ b/ehrp-api-master/ehrp_api.py
@@ -13,8 +13,8 @@ from unitex import init_log_system
 from unitex.config import UnitexConfig
 import yaml
 
-class Extract(Resource):
-    '''Extract API for extracting Biomedical named entities and their respective concept IDs'''
+class Ehrs(Resource):
+    '''Ehrs API for extracting Biomedical named entities and their respective concept IDs'''
     def __init__(self):
         self.reqparse = reqparse.RequestParser()
         # Define allowable arguments
@@ -24,11 +24,11 @@ class Extract(Resource):
                                location=['values', 'json'], help="type of concept to extract")
         self.reqparse.add_argument('file', type=FileStorage, required=False, default=None,
                                location='files', help="optional file to be parsed, at most one of 'text' or 'file' should have data")
-        super(Extract, self).__init__()
+        super(Ehrs, self).__init__()
 
     def post(self):
         '''POST method'''
-        print("POST - Extract")     # for debugging
+        print("POST - Ehrs")     # for debugging
 
         # Get arguments
         args = self.reqparse.parse_args()
@@ -61,27 +61,27 @@ class Extract(Resource):
 
         return jsonify(concepts)
 
-class Lookup(Resource):
-    '''Lookup API for finding the relevant concept ID'''
+class Terms(Resource):
+    '''Terms API for finding the relevant concept ID'''
     def __init__(self):
         self.reqparse = reqparse.RequestParser()
-        self.reqparse.add_argument('text', type=str, required=True, location='args',
+        self.reqparse.add_argument('term', type=str, required=True, location='args',
                                help="text for finding concept id")
-        super(Lookup, self).__init__()
+        super(Terms, self).__init__()
 
     def get(self):
         '''GET method'''
-        print("GET - Lookup")         # for debugging
+        print("GET - Terms")         # for debugging
 
         # Get argument
         args = self.reqparse.parse_args()
-        text = args['text']
+        term = args['term']
         
         # Make into a singleton list, as expected by 'extract_concepts'
-        text = [text]
+        term = [term]
 
         # Get results
-        concepts = extract_concepts(OPTIONS, ALL_GROUPINGS, ALL_DICTS_AND_ONTOLOGIES, text, ['lookup'])
+        concepts = extract_concepts(OPTIONS, ALL_GROUPINGS, ALL_DICTS_AND_ONTOLOGIES, term, ['lookup'])
 
         return jsonify(concepts)
 
@@ -142,8 +142,8 @@ def main():
         return error
 
     # Make extract and lookup pages available
-    api.add_resource(Extract, '/ehrs')
-    api.add_resource(Lookup, '/terms')
+    api.add_resource(Ehrs, '/ehrs')
+    api.add_resource(Terms, '/terms')
     app.run(host=args.host, port=args.port)
 
     # Free resources

--- a/ehrp-api-master/ehrp_api.py
+++ b/ehrp-api-master/ehrp_api.py
@@ -75,10 +75,9 @@ class Terms(Resource):
 
         # Get argument
         args = self.reqparse.parse_args()
-        term = args['term']
-        
+
         # Make into a singleton list, as expected by 'extract_concepts'
-        term = [term]
+        term = [args['term']]
 
         # Get results
         concepts = extract_concepts(OPTIONS, ALL_GROUPINGS, ALL_DICTS_AND_ONTOLOGIES, term, ['lookup'])


### PR DESCRIPTION
### Added a version to the URI.
If there are any changes to how the API works, you do not want the programs that use this API to go under total reconstruction as well. Adding a version to the URI will help support older versions of this API, while letting others use the newer version of the API.

---

### Changed all instances of `lookup` -> `terms` and `extract` -> `ehrs`.
According to the REST principle for designing APIs, you want the endpoint of paths to be nouns. This is because the HTTP requests (GET and POST in our case) already include the verbs. `GET /terms` and `POST /ehrs` sounds more natural than `GET /lookup` and `POST /extract`.

In addition, these nouns should be representative of the resource collection. I debated between `terms` and `umls`, but ultimately went with `terms`. You'll see why in the next section.

---

### Changed the query field of `terms` (previously `lookup`) from `text` -> `term`.
The REST principle states that you want resource collections to be plural and an instance of a resource to be singular. The resource collection is `terms` so the resource should be `term`.

---

### Changed the links in the README to fit above changes
You'll notice that `Lookup` and `Extract` are still there since I'm still learning about how to document APIs. I will start on the documentation in the upcoming weeks.
